### PR TITLE
Fix for API .search methods no longer specifying the namespace opensearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
   
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/Lastfm/Client/LastfmAPIClient.php
+++ b/Lastfm/Client/LastfmAPIClient.php
@@ -9,30 +9,31 @@ namespace BinaryThinking\LastfmBundle\Lastfm\Client;
  */
 abstract class LastfmAPIClient
 {
-    
+
     const API_ROOT_URL = 'http://ws.audioscrobbler.com/2.0/';
     const RESPONSE_STATUS_OK = 'ok';
     const RESPONSE_STATUS_FAILED = 'failed';
-    
+
     protected $apiKey;
-    
+
     protected $apiSecret;
-    
+
     protected $cURL;
-    
+
     public function __construct($apiKey, $apiSecret)
     {
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;
-        
+
         $this->cURL = curl_init();
-        
+
+        curl_setopt($this->cURL, CURLOPT_CONNECTTIMEOUT, 3);
         curl_setopt($this->cURL, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($this->cURL, CURLOPT_USERAGENT, 'BinaryThinkingLastfmBundle for Symfony');
         curl_setopt($this->cURL, CURLOPT_URL, self::API_ROOT_URL);
         curl_setopt($this->cURL, CURLOPT_POST, 1);
     }
-    
+
     public function __destruct() {
         curl_close($this->cURL);
     }
@@ -47,13 +48,26 @@ abstract class LastfmAPIClient
         $httpQuery = http_build_query($params);
         curl_setopt($this->cURL, CURLOPT_POSTFIELDS, $httpQuery);
         $cURLResponse = curl_exec($this->cURL);
+
+        // better fix for malformed returned <type>.search xml from API
+        // substitute xml header
+        $header = '<results';
+        $namespaced_header = '<results xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"';
+        if (
+            preg_match('/\.search$/', $params['method']) &&
+           !preg_match('/\:opensearch/', $cURLResponse)
+           ) {
+            $cURLResponse = str_replace($header, $namespaced_header,
+                                        $cURLResponse);
+        }
+
         $response = new \SimpleXMLElement($cURLResponse);
-        
+
         $this->validateResponse($response);
-        
+
         return $response;
     }
-    
+
     /**
      * @codeCoverageIgnore since only called from ignored call method
      */
@@ -66,5 +80,5 @@ abstract class LastfmAPIClient
             throw new \Exception('Invalid response');
         }
     }
-    
+
 }


### PR DESCRIPTION
Added a timeout on exchanges with last.fm to stop it completely stalling things.


A revised version of @black-bullet’s Geo additions to follow when I have Chart code/tests written.